### PR TITLE
Migrate to Swift 5.8

### DIFF
--- a/.github/workflows/spm-build-test.yml
+++ b/.github/workflows/spm-build-test.yml
@@ -11,9 +11,11 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
+    - name: Xcode Version
+      run: sudo xcode-select --switch /Applications/Xcode_14.3.app
     - name: Lint
       run: swift package plugin --allow-writing-to-package-directory swiftformat --lint
     - name: Build

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "8d3dc46b96d0f19fb44ff14b5e0570a941afe859",
-        "version" : "0.51.2"
+        "revision" : "fee7e1a1ac9518cfe3c4673382368641ccbdc62c",
+        "version" : "0.51.7"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.51.2")
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.51.7")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![MIT License](https://img.shields.io/github/license/vsanthanam/Athena)](https://github.com/vsanthanam/Athena/blob/main/LICENSE)
 [![Package Releases](https://img.shields.io/github/v/release/vsanthanam/Athena)](https://github.com/vsanthanam/Athena/releases)
 [![Build Statis](https://img.shields.io/github/actions/workflow/status/vsanthanam/Athena/spm-build-test.yml)](https://github.com/vsanthanam/Athena/actions)
-[![Swift Version](https://img.shields.io/badge/swift-5.7-critical)](https://swift.org)
+[![Swift Version](https://img.shields.io/badge/swift-5.8-critical)](https://swift.org)
 [![Supported Platforms](https://img.shields.io/badge/platform-iOS%2012-lightgrey)](https://developer.apple.com)
 
 Athena is a library that provides type-safe APIs for working with JSON objects in Swift. It provides an idiomatic solution that is both faster and easier to use than Foundation's `JSONSerialization` API. It takes advantage of modern Swift language features, and provides APIs for easily creating, mutating, serializing, and deserializing JSON values. It also provides a system to easily encode other Swift types into a JSON representation and decode those same types from correctly shaped JSON values.

--- a/generate-static-site.sh
+++ b/generate-static-site.sh
@@ -9,7 +9,7 @@ else
     rm -rf ~/Library/Developer/Xcode/DerivedData
     xcodebuild docbuild -scheme Athena \
     -destination generic/platform=iOS \
-    OTHER_DOCC_FLAGS="--transform-for-static-hosting --hosting-base-path Athena/docs --output-path docs"
+    OTHER_DOCC_FLAGS="--include-extended-types --transform-for-static-hosting --hosting-base-path Athena/docs --output-path docs"
     tail -n +2 README.md > README-2.md && mv README-2.md README.md
     git add .
     git commit -m 'Synchronize Hompage & Publish Documentation'


### PR DESCRIPTION
- Migrate to Package Tools 5.8
- Update SwiftFormat SPM Plugin Version
- Update GitHub Actions config to use macOS Ventura / Xcode 14.3