### PR TITLE
Add Extension Documentation

### DIFF
--- a/generate-static-site.sh
+++ b/generate-static-site.sh
@@ -2,7 +2,7 @@
 branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
 
 run_docc () {
-   swift package --allow-writing-to-directory docs generate-documentation --target Athena --disable-indexing --transform-for-static-hosting --hosting-base-path Athena/docs --output-path docs
+   swift package --allow-writing-to-directory docs generate-documentation --target Athena --disable-indexing --transform-for-static-hosting --hosting-base-path Athena/docs --output-path docs --include-extended-types
 }
 
 create_branches () {


### PR DESCRIPTION
Add documentation to extension for type that live in the Swift Standard Library and Foundation, using the new features in the Swift 5.8 toolchain and the latest release of the SPM DocC Plugin
